### PR TITLE
Bunch of GWT fixes; HyperRunner works on the web!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ plugin-9patch/build/
 plugin-performance/build/
 plugin-tiled/build/
 plugin-skin-composer/build/
-/.gradle/**
+.gradle
 /build/
 /out/
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ plugin-9patch/build/
 plugin-performance/build/
 plugin-tiled/build/
 plugin-skin-composer/build/
-/.gradle/
+/.gradle/**
 /build/
 /out/
 .idea/

--- a/TestGame/src/main/java/games/rednblack/hyperrunner/HyperRunner.gwt.xml
+++ b/TestGame/src/main/java/games/rednblack/hyperrunner/HyperRunner.gwt.xml
@@ -7,5 +7,6 @@
 
 	<extend-configuration-property name="artemis.reflect.include" value="games.rednblack.hyperrunner.component" />
 	<extend-configuration-property name="artemis.reflect.include" value="games.rednblack.hyperrunner.system" />
+	<extend-configuration-property name="artemis.reflect.include" value="games.rednblack.hyperrunner.script" />
 
 </module>

--- a/TestGame/src/main/java/games/rednblack/hyperrunner/script/PlayerScript.java
+++ b/TestGame/src/main/java/games/rednblack/hyperrunner/script/PlayerScript.java
@@ -37,7 +37,15 @@ public class PlayerScript extends BasicScript implements PhysicsContact {
     private final Vector2 impulse = new Vector2(0, 0);
     private final Vector2 speed = new Vector2(0, 0);
 
-    private final World mEngine;
+    private World mEngine;
+
+    private World getmEngine() {
+        return mEngine;
+    }
+
+    private void setmEngine(World mEngine) {
+        this.mEngine = mEngine;
+    }
 
     public PlayerScript(World engine) {
         mEngine = engine;

--- a/WebTest/src/main/java/games/rednblack/hyperrunner/GdxDefinition.gwt.xml
+++ b/WebTest/src/main/java/games/rednblack/hyperrunner/GdxDefinition.gwt.xml
@@ -4,8 +4,7 @@
 	<source path="" />
 	<inherits name="com.badlogic.gdx.backends.gdx_backends_gwt" />
 
-	<extend-configuration-property name="gdx.reflect.include" value="com.badlogic.ashley" />
-
+	<inherits name='com.artemis.backends.artemis_backends_gwt' />
 	<inherits name="HyperLap2D" />
 	<inherits name="jsr305" />
 	<inherits name="games.rednblack.hyperrunner.HyperRunner" />

--- a/src/main/resources/HyperLap2D.gwt.xml
+++ b/src/main/resources/HyperLap2D.gwt.xml
@@ -9,6 +9,9 @@
     <inherits name="com.rafaskoberg.gdx.typinglabel.typinglabel" />
 
     <extend-configuration-property name="gdx.reflect.include" value="games.rednblack.editor.renderer"/>
+    <extend-configuration-property name="gdx.reflect.include" value="java.util.HashSet" />
+
+    <extend-configuration-property name="artemis.reflect.include" value="games.rednblack.editor.renderer"/>
 
     <extend-configuration-property name="artemis.reflect.include" value="games.rednblack.editor.renderer.components" />
     <extend-configuration-property name="artemis.reflect.include" value="games.rednblack.editor.renderer.components.sprite" />
@@ -22,5 +25,7 @@
     <extend-configuration-property name="artemis.reflect.include" value="games.rednblack.editor.renderer.systems" />
     <extend-configuration-property name="artemis.reflect.include" value="games.rednblack.editor.renderer.systems.render" />
     <extend-configuration-property name="artemis.reflect.include" value="games.rednblack.editor.renderer.systems.action" />
+
+    <extend-configuration-property name="artemis.reflect.include" value="games.rednblack.editor.renderer.data" />
 
 </module>


### PR DESCRIPTION
There are enough fixes here that going through them via Discord one-by-one would take a while and would be error-prone. So, here's a PR! I mostly needed to add an odd assortment of classes to either artemis' or libGDX's reflection cache, but I also needed to make mWorld, in one of the reflected classes, possible to set with a setter. The setter is private, so nothing new is exposed, but mWorld is no longer final (because it needs to be settable).